### PR TITLE
CORE-25185 cherry-pick upstream: Fix usage of deprecated std::allocator::rebind (#51)

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -41,6 +41,7 @@ has_plugin_after = os.path.exists('include/%s/plugin/%s.after.h' % (spec.package
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <ros/types.h>
 #include <ros/serialization.h>

--- a/src/gencpp/__init__.py
+++ b/src/gencpp/__init__.py
@@ -51,7 +51,7 @@ MSG_TYPE_TO_CPP = {
     'int64': 'int64_t',
     'float32': 'float',
     'float64': 'double',
-    'string': 'std::basic_string<char, std::char_traits<char>, typename ContainerAllocator::template rebind<char>::other > ',
+    'string': 'std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>',
     'time': 'ros::Time',
     'duration': 'ros::Duration',
 }
@@ -86,7 +86,7 @@ def msg_type_to_cpp(type_):
 
     if (is_array):
         if (array_len is None):
-            return 'std::vector<%s, typename ContainerAllocator::template rebind<%s>::other > ' % (cpp_type, cpp_type)
+            return 'std::vector<%s, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<%s>>' % (cpp_type, cpp_type)
         else:
             return 'boost::array<%s, %s> ' % (cpp_type, array_len)
     else:


### PR DESCRIPTION
std::allocator::rebind was deprecated in C++17 and removed in C++20. Instead std::allocator_traits::rebind_alloc should be used now.